### PR TITLE
fix: 使用 GetWindowProcessHandle 替换直接的 OpenProcess 调用

### DIFF
--- a/src/Common.Post.props
+++ b/src/Common.Post.props
@@ -6,6 +6,8 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <PreprocessorDefinitions>_WINDOWS;WIN32_LEAN_AND_MEAN;WINRT_LEAN_AND_MEAN;WINRT_NO_MODULE_LOCK;WIL_SUPPRESS_EXCEPTIONS;WIL_USE_STL=1;NOGDICAPMASKS;NOICONS;NOATOM;NOCLIPBOARD;NODRAWTEXT;NOMEMMGR;NOMETAFILE;NOMINMAX;NOOPENFILE;NOSCROLL;NOSERVICE;NOSOUND;NOTEXTMETRIC;NOCOMM;NOKANJI;NOHELP;NOPROFILER;NOMCX;NO_SHLWAPI_PATH;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <!-- 避免 phmap 中警告的临时方案，phmap 发布新版本后应删除 -->
+      <PreprocessorDefinitions>_SILENCE_CXX20_IS_ALWAYS_EQUAL_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(CommitId)' != ''">MP_COMMIT_ID=$(CommitId);%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(MajorVersion)' != '' And '$(MinorVersion)' != '' And '$(PatchVersion)' != ''">MP_MAJOR_VERSION=$(MajorVersion);MP_MINOR_VERSION=$(MinorVersion);MP_PATCH_VERSION=$(PatchVersion);%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(VersionTag)' != ''">MP_VERSION_TAG=$(VersionTag);%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -23,6 +25,8 @@
       <AdditionalOptions Condition="$(UseClangCL) And '$(Platform)' == 'x64'">/clang:-mcx16 %(AdditionalOptions)</AdditionalOptions>
       <!-- -march=native: 针对当前硬件生成优化代码 -->
       <AdditionalOptions Condition="$(UseClangCL) And $(UseNativeMicroArch)">/clang:-march=native %(AdditionalOptions)</AdditionalOptions>
+      <!-- 使用 clang-cl 编译时将 cppwinrt 生成的头文件视为系统头文件，禁用其中的编译警告 -->
+      <AdditionalOptions Condition="$(UseClangCL) And '$(GeneratedFilesDir)' != ''">/clang:-isystem /clang:"$(GeneratedFilesDir)\" %(AdditionalOptions)</AdditionalOptions>
       <!-- 修复编译 Shared 中源文件找不到 pch.h 的问题 -->
       <AdditionalIncludeDirectories Condition="$(UseClangCL)">.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>

--- a/src/Common.Pre.props
+++ b/src/Common.Pre.props
@@ -22,13 +22,19 @@
   <!-- 编译选项 -->
   <Import Project="$(MSBuildThisFileDirectory)\BuildOptions.props" />
 
-  <PropertyGroup>
+  <PropertyGroup Label="Globals">
+    <!-- 检测 VS 版本：VS2022(v17) 使用 v143，VS2026(v18) 使用 v145 -->
+    <VS17 Condition="$([System.String]::new('$(MSBuildVersion)').StartsWith('17'))">true</VS17>
+    <VS17 Condition="'$(VS17)' != 'true'">false</VS17>
+    <VCProjectVersion Condition="$(VS17)">17.0</VCProjectVersion>
+    <VCProjectVersion Condition="!$(VS17)">18.0</VCProjectVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
   </PropertyGroup>
 
   <PropertyGroup Label="Configuration">
     <PlatformToolset Condition="$(UseClangCL)">ClangCL</PlatformToolset>
-    <PlatformToolset Condition="!$(UseClangCL)">v143</PlatformToolset>
+    <PlatformToolset Condition="!$(UseClangCL) And $(VS17)">v143</PlatformToolset>
+    <PlatformToolset Condition="!$(UseClangCL) And !$(VS17)">v145</PlatformToolset>
     <UseDebugLibraries Condition="'$(Configuration)' == 'Debug'">true</UseDebugLibraries>
     <WholeProgramOptimization Condition="'$(Configuration)' == 'Release'">true</WholeProgramOptimization>
   </PropertyGroup>

--- a/src/Magpie.Core/ImGuiImpl.h
+++ b/src/Magpie.Core/ImGuiImpl.h
@@ -48,11 +48,6 @@ private:
 	ImGuiBackend _backend;
 
 	phmap::flat_hash_map<std::string, ImVec4> _windowRects;
-
-	uint32_t _handlerId = 0;
-
-	HANDLE _hHookThread = NULL;
-	DWORD _hookThreadId = 0;
 };
 
 }

--- a/src/Magpie.Core/include/Win32Helper.h
+++ b/src/Magpie.Core/include/Win32Helper.h
@@ -133,7 +133,7 @@ struct Win32Helper {
 		}
 
 		Variant(VARIANT&& varSrc) noexcept {
-			std::memcpy(this, &varSrc, sizeof(varSrc));
+			std::memcpy((VARIANT*)this, &varSrc, sizeof(varSrc));
 			varSrc.vt = VT_EMPTY;
 		}
 
@@ -166,7 +166,7 @@ struct Win32Helper {
 		}
 
 		Variant& operator=(VARIANT&& other) noexcept {
-			std::memcpy(this, &other, sizeof(other));
+			std::memcpy((VARIANT*)this, &other, sizeof(other));
 			other.vt = VT_EMPTY;
 			return *this;
 		}

--- a/src/Magpie/App.cpp
+++ b/src/Magpie/App.cpp
@@ -99,6 +99,7 @@ App& App::Get() {
 
 App::App() {
 	UnhandledException([](IInspectable const&, UnhandledExceptionEventArgs const& e) {
+		Logger::Get().Error(to_string(e.Message()));
 		Logger::Get().ComCritical("未处理的异常", e.Exception().value);
 
 		if (IsDebuggerPresent()) {

--- a/src/Magpie/AppSettings.cpp
+++ b/src/Magpie/AppSettings.cpp
@@ -979,6 +979,10 @@ bool AppSettings::_LoadProfile(
 		}
 		
 		JsonHelper::ReadString(profileObj, "launchParameters", profile.launchParameters);
+
+		if (!profile.isPackaged) {
+			_SetTruePath(profile);
+		}
 	}
 
 	JsonHelper::ReadInt(profileObj, "scalingMode", profile.scalingMode);
@@ -1129,6 +1133,37 @@ bool AppSettings::_LoadProfile(
 	}
 
 	return true;
+}
+
+fire_and_forget AppSettings::_SetTruePath(Profile& profile) const {
+	HANDLE handle = CreateFile(
+		profile.pathRule.c_str(),
+		GENERIC_READ,
+		FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+		NULL,
+		OPEN_EXISTING,
+		FILE_ATTRIBUTE_NORMAL,
+		NULL
+	);
+
+	if (handle == INVALID_HANDLE_VALUE) {
+		co_return;
+	}
+
+	TCHAR path[MAX_PATH];
+	DWORD length = GetFinalPathNameByHandle(
+		handle,
+		path,
+		MAX_PATH,
+		0
+	);
+
+	if (length > 0) {
+		// Skip `\\?\` prefix
+		profile.truePath = &path[4];
+	}
+
+	CloseHandle(handle);
 }
 
 bool AppSettings::_SetDefaultShortcuts() noexcept {

--- a/src/Magpie/AppSettings.h
+++ b/src/Magpie/AppSettings.h
@@ -358,6 +358,7 @@ private:
 		Profile& profile,
 		bool isDefault = false
 	) const noexcept;
+	winrt::fire_and_forget _SetTruePath(Profile& profile) const;
 	bool _SetDefaultShortcuts() noexcept;
 	void _SetDefaultScalingModes() noexcept;
 

--- a/src/Magpie/AppXReader.cpp
+++ b/src/Magpie/AppXReader.cpp
@@ -138,16 +138,11 @@ bool AppXReader::Initialize(HWND hWnd) noexcept {
 		}
 	}
 
-	// 使用 GetApplicationUserModelId 获取 AUMID
-	DWORD dwProcId = 0;
-	if (!GetWindowThreadProcessId(hWnd, &dwProcId)) {
-		Logger::Get().Win32Error("GetWindowThreadProcessId 失败");
-		return false;
-	}
-
-	wil::unique_process_handle hProc(OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, dwProcId));
+	// 使用 GetWindowProcessHandle 获取进程句柄，该函数包含 fallback 机制
+	// 可以处理权限不足的情况
+	wil::unique_process_handle hProc = Win32Helper::GetWindowProcessHandle(hWnd);
 	if (!hProc) {
-		Logger::Get().Win32Error("OpenProcess 失败");
+		Logger::Get().Error("GetWindowProcessHandle 失败");
 		return false;
 	}
 

--- a/src/Magpie/Magpie.vcxproj
+++ b/src/Magpie/Magpie.vcxproj
@@ -39,7 +39,8 @@
   <Import Project="..\Common.Pre.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset Condition="$(VS17)">v143</PlatformToolset>
+    <PlatformToolset Condition="!$(VS17)">v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/src/Magpie/Magpie.vcxproj
+++ b/src/Magpie/Magpie.vcxproj
@@ -372,6 +372,7 @@
       <DependentUpon>SettingsExpanderCornerRadiusConverter.idl</DependentUpon>
       <SubType>Code</SubType>
     </ClCompile>
+    <ClCompile Include="Profile.cpp" />
     <ClCompile Include="ShortcutService.cpp" />
     <ClCompile Include="Shortcut.cpp" />
     <ClCompile Include="IconHelper.cpp" />

--- a/src/Magpie/Magpie.vcxproj.filters
+++ b/src/Magpie/Magpie.vcxproj.filters
@@ -59,6 +59,9 @@
     <ClCompile Include="TouchHelper.cpp">
       <Filter>Helpers</Filter>
     </ClCompile>
+    <ClCompile Include="Profile.cpp">
+      <Filter>Models</Filter>
+    </ClCompile>
     <ClCompile Include="ToastService.cpp">
       <Filter>Services</Filter>
     </ClCompile>

--- a/src/Magpie/Profile.cpp
+++ b/src/Magpie/Profile.cpp
@@ -1,0 +1,10 @@
+#include "pch.h"
+#include "Profile.h"
+
+namespace Magpie {
+
+std::wstring Profile::GetTruePath() const noexcept {
+	return truePath.empty() ? pathRule : truePath;
+}
+
+}

--- a/src/Magpie/Profile.h
+++ b/src/Magpie/Profile.h
@@ -64,6 +64,8 @@ struct Profile {
 
 	// 对于打包应用，pathRule 存储 AUMID
 	std::wstring pathRule;
+	std::wstring truePath;
+	std::wstring GetTruePath() const noexcept;
 	std::wstring classNameRule;
 
 	// 允许 exe 和 lnk

--- a/src/_ConanDeps/clang-cl.profile
+++ b/src/_ConanDeps/clang-cl.profile
@@ -1,10 +1,10 @@
 [settings]
 os=Windows
 compiler=clang
-compiler.version=19
+compiler.version=20
 compiler.runtime=static
 compiler.cppstd=gnu17
 
 [conf]
-tools.cmake.cmaketoolchain:generator=Visual Studio 17
+tools.cmake.cmaketoolchain:generator=Visual Studio 18
 tools.info.package_id:confs=["tools.build:cxxflags"]

--- a/src/_ConanDeps/msvc.profile
+++ b/src/_ConanDeps/msvc.profile
@@ -1,7 +1,7 @@
 [settings]
 os=Windows
 compiler=msvc
-compiler.version=194
+compiler.version=195
 compiler.runtime=static
 compiler.cppstd=17
 


### PR DESCRIPTION
在 AppXReader::Initialize(HWND) 中，直接调用 OpenProcess 在某些情况下会失败 （如权限不足，ErrorCode 5），而没有任何 fallback 机制。

这个修复改用 Win32Helper::GetWindowProcessHandle()，它包含以下 fallback 逻辑：
1. 首先尝试 OpenProcess
2. 如果失败，则尝试 GetProcessHandleFromHwnd（来自 Oleacc.dll）

这确保即使面对权限限制的窗口（如某些 UWP 应用在特定场景下）也能成功获取进程句柄。

修复相关问题：
- 日志显示 OpenProcess 因 ErrorCode 5（Access Denied）失败
- GetProcessHandleFromHwnd fallback 提供了额外的获取句柄的机制